### PR TITLE
Fix output of count of successfully linted JSON files. See #4 and #5.

### DIFF
--- a/tasks/jsonlint.js
+++ b/tasks/jsonlint.js
@@ -12,24 +12,22 @@ module.exports = function (grunt) {
   var jsonlint = require('jsonlint');
 
   grunt.registerMultiTask("jsonlint", "Validate JSON files.", function () {
-    if (this.files != null) {
+    if (this.filesSrc != null) {
       var failed = 0;
-      this.files.forEach(function (mapping) {
-        mapping.src.forEach(function (file) {
-          grunt.log.debug('Validating "' + file + '"...');
+      this.filesSrc.forEach(function (file) {
+        grunt.log.debug('Validating "' + file + '"...');
 
-          try {
-            jsonlint.parse(grunt.file.read(file));
-            grunt.verbose.ok('File "' + file + '" is valid JSON.');
-          }
-          catch (e) {
-            failed++;
-            grunt.log.error('File "' + file + '" failed JSON validation.');
-            grunt.fail.warn(e);
-          }
-        });
+        try {
+          jsonlint.parse(grunt.file.read(file));
+          grunt.verbose.ok('File "' + file + '" is valid JSON.');
+        }
+        catch (e) {
+          failed++;
+          grunt.log.error('File "' + file + '" failed JSON validation.');
+          grunt.fail.warn(e);
+        }
       });
-      var successful = this.files.length - failed;
+      var successful = this.filesSrc.length - failed;
       grunt.log.ok(successful + ' file' + (successful === 1 ? '' : 's') + ' lint free.');
     }
   });


### PR DESCRIPTION
Also, use `this.filesSrc` to save us another `forEach` loop.
