### PR TITLE
Further customize pretty-printing of CJSON/JSON5 input

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ Add the following (multi-)task to your `Gruntfile`:
           indent: 2,
           sortKeys: false,
           pruneComments: false,
-          stripObjectKeys: false
+          stripObjectKeys: false,
+          enforceDoubleQuotes: false,
+          enforceSingleQuotes: false,
+          trimTrailingCommas: false
         }
       }
     }
@@ -83,6 +86,9 @@ Add the following (multi-)task to your `Gruntfile`:
 * `sortKeys`, when `true` keys of objects in the output JSON will be sorted alphabetically (`format` has to be set to `true`)
 * `pruneComments`, when `true` comments will be omitted from the prettified output (CJSON feature, `prettyPrint` has to be set to `true`)
 * `stripObjectKeys`, when `true` quotes surrounding object keys will be stripped if the key is a JavaScript identifier name (JSON5 feature, `prettyPrint` has to be set to `true`)
+* `enforceDoubleQuotes`, when `true` string literals will be consistently surrounded by double quotes (JSON5 feature, `prettyPrint` has to be set to `true`)
+* `enforceSingleQuotes`, when `true` string literals will be consistently surrounded by single quotes (JSON5 feature, `prettyPrint` has to be set to `true`)
+* `trimTrailingCommas`, when `true` trailing commas after all array items and object entries will be omitted (JSON5 feature, `prettyPrint` has to be set to `true`)
 
 # Schema Validation
 

--- a/lib/grunt-jsonlint-task.js
+++ b/lib/grunt-jsonlint-task.js
@@ -37,6 +37,9 @@ module.exports = function makeTask(grunt, jsonlint, validator, sorter, printer) 
       sortKeys: false,
       pruneComments: false,
       stripObjectKeys: false,
+      enforceDoubleQuotes: false,
+      enforceSingleQuotes: false,
+      trimTrailingCommas: false,
       formatter: 'prose',
       reporter: 'exception'
     });
@@ -80,7 +83,10 @@ module.exports = function makeTask(grunt, jsonlint, validator, sorter, printer) 
         formatted = `${printer.print(tokens, {
           indent: options.indent,
           pruneComments: options.pruneComments,
-          stripObjectKeys: options.stripObjectKeys
+          stripObjectKeys: options.stripObjectKeys,
+          enforceDoubleQuotes: options.enforceDoubleQuotes,
+          enforceSingleQuotes: options.enforceSingleQuotes,
+          trimTrailingCommas: options.trimTrailingCommas
         })}\n`;
       }
       if (formatted) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,9 +123,9 @@
       }
     },
     "@prantlf/jsonlint": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@prantlf/jsonlint/-/jsonlint-10.1.1.tgz",
-      "integrity": "sha512-1voxxQIJFriungUhOFVveGzKYR5bdC8Cts4L0WC9UmKFeV1powJwlD3Phiey0jZDutF1IJvF5KH2h6kJrCB9yw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@prantlf/jsonlint/-/jsonlint-10.2.0.tgz",
+      "integrity": "sha512-KMFfds0peWLLfCu3bhClTiEN0tdj/Z86QJvn1awKHws6r+Sx6T3a44Eadz6OvqN6ZpsRkqaRpZxqddvvDAdDZQ==",
       "requires": {
         "ajv": "6.10.2",
         "commander": "4.0.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@prantlf/jsonlint": "10.1.1"
+    "@prantlf/jsonlint": "10.2.0"
   },
   "devDependencies": {
     "async": "^3.0.1",

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -161,6 +161,8 @@ describe('grunt-jsonlint task', () => {
   it('reformats the input JSON file with object keys sorted', testSortingObjectKeys);
 
   it('does not sort keys unless asked to do so', testNotSortingObjectKeys);
+
+  it('prettifies JSON5 input', testPrettyPrintingFile);
 });
 
 function createPassingJsonlintSpy() {
@@ -327,4 +329,29 @@ function testNotSortingObjectKeys() {
   expect(formatted).to.be(`${sourceJson}\n`);
 
   grunt.file.delete(`${__dirname}/dont-reformat-this.json`);
+}
+
+function testPrettyPrintingFile() {
+  const options = {
+    mode: 'json5',
+    prettyPrint: true,
+    indent: '',
+    pruneComments: true,
+    stripObjectKeys: true,
+    enforceDoubleQuotes: true,
+    trimTrailingCommas: true
+  };
+
+  grunt.file.write(`${__dirname}/reformat-this.json`, '/*json5*/{"key":\'value\',}');
+  runWithFiles(grunt, jsonlint, [ 'test/reformat-this.json' ], options);
+
+  const formatted = grunt.file.read(`${__dirname}/reformat-this.json`);
+  const lines = formatted.split(/\r?\n/);
+  expect(lines).to.have.length(4);
+  expect(lines[0]).to.be('{');
+  expect(lines[1]).to.be('key: "value"');
+  expect(lines[2]).to.be('}');
+  expect(lines[3]).to.be.empty();
+
+  grunt.file.delete(`${__dirname}/reformat-this.json`);
 }

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -195,10 +195,10 @@ function createTaskContext(data) {
   const target = 'unit test';
   const normalizedFiles = grunt.task.normalizeMultiTaskFiles(data, target);
 
-  const filesSrc = normalizedFiles.map(f => f.src).reduce((prev, curr) => prev.concat(curr), []);
+  const filesSrc = normalizedFiles.map((f) => f.src).reduce((prev, curr) => prev.concat(curr), []);
 
   const optionsFunc = (function optionsFunc(options) {
-    return defaultOptions => _.extend(defaultOptions, options);
+    return (defaultOptions) => _.extend(defaultOptions, options);
   }(data.options));
 
   return {
@@ -216,7 +216,7 @@ function createTaskContext(data) {
 }
 
 function runWithFiles(gruntForTest, jsonlintForTest, files, options) {
-  const gruntFiles = files.map(file => ({
+  const gruntFiles = files.map((file) => ({
     src: file
   }));
 

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -197,10 +197,10 @@ function createTaskContext(data) {
   const target = 'unit test';
   const normalizedFiles = grunt.task.normalizeMultiTaskFiles(data, target);
 
-  const filesSrc = normalizedFiles.map((f) => f.src).reduce((prev, curr) => prev.concat(curr), []);
+  const filesSrc = normalizedFiles.map(f => f.src).reduce((prev, curr) => prev.concat(curr), []);
 
   const optionsFunc = (function optionsFunc(options) {
-    return (defaultOptions) => _.extend(defaultOptions, options);
+    return defaultOptions => _.extend(defaultOptions, options);
   }(data.options));
 
   return {
@@ -218,7 +218,7 @@ function createTaskContext(data) {
 }
 
 function runWithFiles(gruntForTest, jsonlintForTest, files, options) {
-  const gruntFiles = files.map((file) => ({
+  const gruntFiles = files.map(file => ({
     src: file
   }));
 


### PR DESCRIPTION
Support options of the underlying jsonlint to reformat the JSON input consistently including unification of string quotes and trimming trailing commas.