### PR TITLE
Test against node version 13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "13"
   - "12"
   - "10"
   - "8"


### PR DESCRIPTION
In order to support node v14 when it comes out, let's start testing against Node v13.