### PR TITLE
Require node v10.12+ to match eslint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "14"
   - "12"
-  - "10"
+  - "10.12"
 cache:
   directories:
     - ~/.npm

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "LICENSE-MIT"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10.12"
   },
   "repository": "https://github.com/brandonramirez/grunt-jsonlint",
   "bugs": "https://github.com/brandonramirez/grunt-jsonlint/issues",


### PR DESCRIPTION
https://medium.com/@PhilipAndrews/error-eslint-typeerror-createrequire-is-not-a-function-15890e9942f7