### PR TITLE
Get continuous integration working on v2

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-plugin-import": "^2.29.1",
         "expect.js": "^0.3.1",
         "fs-writefile-promise": "^3.0.2",
-        "grunt": "^1.6.1",
+        "grunt": "1.5.3",
         "grunt-eslint": "^21.1.0",
         "grunt-mocha-test": "^0.13.3",
         "lodash": "^4.17.21",
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/dateformat": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -1560,18 +1560,31 @@
       }
     },
     "node_modules/findup-sync": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
-      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
       "dev": true,
       "dependencies": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
+        "glob": "~5.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "dev": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/fined": {
@@ -1908,30 +1921,32 @@
       }
     },
     "node_modules/grunt": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
-      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
+      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
       "dev": true,
       "dependencies": {
-        "dateformat": "~4.6.2",
+        "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~5.0.0",
+        "findup-sync": "~0.3.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.6.3",
+        "iconv-lite": "~0.4.13",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "mkdirp": "~1.0.4",
+        "nopt": "~3.0.6",
+        "rimraf": "~3.0.2"
       },
       "bin": {
         "grunt": "bin/grunt"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=8"
       }
     },
     "node_modules/grunt-eslint": {
@@ -2138,18 +2153,6 @@
         "nopt": "bin/nopt.js"
       }
     },
-    "node_modules/grunt/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/grunt/node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -2161,6 +2164,33 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/grunt/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/grunt/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/has": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-import": "^2.29.1",
     "expect.js": "^0.3.1",
     "fs-writefile-promise": "^3.0.2",
-    "grunt": "^1.6.1",
+    "grunt": "1.5.3",
     "grunt-eslint": "^21.1.0",
     "grunt-mocha-test": "^0.13.3",
     "lodash": "^4.17.21",


### PR DESCRIPTION
We need to pin grunt to version 1.5.3 specifically. v1.6+ is deemed compatible from a semantic versioning standpoint, however, it is not compatible with node versions < 14, which makes it a breaking change.

Also, the tests don't pass on node 6. Disabling testing on node 6 so that we can at least have automated testing working on v8, v10, and v12.